### PR TITLE
Schedule settings

### DIFF
--- a/classes/Observer.php
+++ b/classes/Observer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace mod_exportgrades;
+
+defined('MOODLE_INTERNAL') || die();
+
+class Observer
+{
+
+    /**
+     * Funcion se ejecuta cuando se guardan las settings
+     *
+     * @param \core\event\config_log_created $event The event object.
+     */
+    public static function config_updated(\core\event\config_log_created $event)
+    {
+        global $DB;
+
+        // Chequea si las settings the frecuencia es distinta
+        if ($event->other['plugin'] === 'mod_exportgrades' && $event->other['name'] === 'export_frequency') {
+           // Obtenemos la frecuencya actual
+            $export_frequency = get_config('mod_exportgrades', 'export_frequency');
+
+            // Definimos el comportamiento x default
+            $default_task = array(
+                'classname' => 'mod_exportgrades\task\grade_export_task',
+                'blocking' => 0,
+                'minute' => '*/1',
+                'hour' => '*',
+                'day' => '*',
+                'month' => '*',
+                'dayofweek' => '*',
+                'disabled' => 0
+            );
+
+            // Obtenemos el task_scheduled de la DB
+            $existing_task = $DB->get_record('task_scheduled', array('classname' => $default_task['classname']));
+
+            // Si ya existe una scheduled task la actualizamos y reseteamos el resto a default
+            if ($existing_task) {
+
+                $existing_task->minute = $default_task['minute'];
+                $existing_task->hour = $default_task['hour'];
+                $existing_task->day = $default_task['day'];
+                $existing_task->month = $default_task['month'];
+                $existing_task->dayofweek = $default_task['dayofweek'];
+                $existing_task->disabled = $default_task['disabled'];
+                switch ($export_frequency) {
+                    case 'daily':
+                        $existing_task->hour = '0';
+                        break;
+                    case 'weekly':
+                        $existing_task->dayofweek = '0';
+                        $existing_task->hour = '0';
+                        break;
+                    case 'monthly':
+                        $existing_task->day = '*/31';  // cada 31 dias
+                        $existing_task->hour = '0';  // a la noche
+                        break;
+                }
+
+                $DB->update_record('task_scheduled', $existing_task);
+            } else {
+                // Insert a new task
+                $DB->insert_record('task_scheduled', (object)$default_task);
+            }
+        }
+    }
+
+}

--- a/classes/task/grade_export_task.php
+++ b/classes/task/grade_export_task.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace mod_exportgrades\classes\task;
+namespace mod_exportgrades\task;
 
-class grade_export_task extends \core\task\scheduled_task {
+use core\task\scheduled_task;
+
+class grade_export_task extends scheduled_task {
 
     public function get_name() {
         return get_string('grade_export_task', 'mod_exportgrades');
@@ -56,5 +58,3 @@ class grade_export_task extends \core\task\scheduled_task {
         return ($current_time - $last_export_time) >= $export_frequency;
     }
 }
-
-?>

--- a/db/events.php
+++ b/db/events.php
@@ -1,0 +1,9 @@
+<?php
+defined('MOODLE_INTERNAL') || die();
+
+$observers = array(
+    array(
+        'eventname'   => '\core\event\config_log_created',
+        'callback'    => 'mod_exportgrades\Observer::config_updated',
+    ),
+);


### PR DESCRIPTION
+- fix: schedule task no aparecia, problema de namespace
+ events.php -> nos permite generear un observer que espera al save de la settings del plugin
+ clase Observer.php -> modifica los valores de la scheduled task